### PR TITLE
Feature: update role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ This is the changelog of
 - Added: tuned role
 - Added: sudo role
 - Updated: user role to point to sudo role
+- Added: dnf automatic to dnf role
+- Added: update role
+- Added: update playbook
+- Rename: playbook naming changed
 
 ## [MAJOR.MINOR.PATCH-LABEL] - YYYYMMDD
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ The following roles are bundled with this collection.
 The following playbooks are bundled with this collection and provide examples
 for role usage or templates for further improvements.
 
-- [minimal server](playbooks/minimal_server.yml)
+- [configure minimal server](playbooks/configure_minimal_server.yml)
+- [update machine](playbooks/update_machine.yml)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following roles are bundled with this collection.
 - [sudo](roles/sudo/README.md)
 - [thermald](roles/thermald/README.md)
 - [tuned](roles/tuned/README.md)
+- [update](roles/update/README.md)
 - [user](roles/user/README.md)
 
 ### Playbooks

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -4,24 +4,24 @@ Plain ToDo file for whiletruedoio.general.
 
 ## Release v1.0.0
 
-- [ ] update playbooks
-  - [ ] update role
+- [x] update playbooks
+  - [x] update role
 
-- [ ] minimal server playbook
+- [x] minimal server playbook
   - [x] bash role
   - [x] chrony role (client only)
   - [x] dnf role
-    - [ ] add dnf automatic
+    - [x] add dnf automatic
   - [x] firewalld role
   - [x] misc role
   - [x] selinux role
-  - [x] sshd role
+  - [x] ssh role
   - [x] sudo role
   - [x] user role
     - [x] sudo-config per user
 
 - [ ] base server playbook
-  - [ ] minimal server playbook
+  - [x] minimal server playbook
   - [ ] kdump role
   - [ ] pcp role
   - [x] thermald role
@@ -37,6 +37,8 @@ Plain ToDo file for whiletruedoio.general.
   - [x] avahi role
 
 - [ ] Update user documentation
+- [ ] All roles need proper argument specs
+- [ ] All roles need proper integration tests
 
 ## Release v2.0.0
 

--- a/playbooks/configure_minimal_server.yml
+++ b/playbooks/configure_minimal_server.yml
@@ -1,45 +1,67 @@
 ---
-# playbooks/minimal.yml for whiletruedoio.general
+# playbooks/minimal_server.yml
 #
-# This playbook provides some minimal automation for servers and desktops.
-# It can be used as a base-line for further automations.
+# This playbook provides some minimal automation for servers.
+# It can be used as a base-line for further automation.
 
-- name: "Minimal Server"
+- name: "Configure Minimal Server"
   hosts: "all"
 
   tasks:
 
-    - name: "Import misc Role"
+    - name: "Import bash Role"
       ansible.builtin.import_role:
-        name: "whiletruedoio.general.misc"
-
-    - name: "Import dnf Role"
-      ansible.builtin.import_role:
-        name: "whiletruedoio.general.dnf"
+        name: "whiletruedoio.general.bash"
+      tags:
+        - "bash"
 
     - name: "Import chrony Role"
       ansible.builtin.import_role:
         name: "whiletruedoio.general.chrony"
+      tags:
+        - "chrony"
 
-    - name: "Import bash Role"
+    - name: "Import dnf Role"
       ansible.builtin.import_role:
-        name: "whiletruedoio.general.bash"
-
-    - name: "Import selinux Role"
-      ansible.builtin.import_role:
-        name: "whiletruedoio.general.selinux"
+        name: "whiletruedoio.general.dnf"
+      tags:
+        - "dnf"
 
     - name: "Import firewalld Role"
       ansible.builtin.import_role:
         name: "whiletruedoio.general.firewalld"
+      tags:
+        - "firewalld"
+
+    - name: "Import misc Role"
+      ansible.builtin.import_role:
+        name: "whiletruedoio.general.misc"
+      tags:
+        - "misc"
+
+    - name: "Import selinux Role"
+      ansible.builtin.import_role:
+        name: "whiletruedoio.general.selinux"
+      tags:
+        - "selinux"
 
     - name: "Import ssh Role"
       ansible.builtin.import_role:
         name: "whiletruedoio.general.ssh"
+      tags:
+        - "ssh"
+
+    - name: "Import sudo Role"
+      ansible.builtin.import_role:
+        name: "whiletruedoio.general.sudo"
+      tags:
+        - "ssh"
 
     - name: "Import user Role"
       ansible.builtin.import_role:
         name: "whiletruedoio.general.user"
+      tags:
+        - "user"
       vars:
         user_users:
           - username: "admin"

--- a/playbooks/update_machine.yml
+++ b/playbooks/update_machine.yml
@@ -1,0 +1,14 @@
+---
+# playbooks/update.yml
+
+- name: "Update System"
+  hosts: "all"
+
+  tasks:
+
+    - name: "Import update Role"
+      ansible.builtin.import_role:
+        name: "whiletruedoio.general.update"
+      tags:
+        - "update"
+...

--- a/roles/avahi/defaults/main.yml
+++ b/roles/avahi/defaults/main.yml
@@ -3,7 +3,9 @@
 
 ## Package Management
 
-avahi_package_names: "avahi"
+avahi_package_names:
+  - "avahi"
+  - "nss-mdns"
 avahi_package_state: "present"
 
 ## Service Management

--- a/roles/avahi/tasks/main.yml
+++ b/roles/avahi/tasks/main.yml
@@ -53,7 +53,7 @@
 
 ## Checks
 
-- name: "Import Checks for avahi"
+- name: "Import check Tasks"
   ansible.builtin.import_tasks: "check.yml"
   when:
     - "avahi_checks_enabled | bool"

--- a/roles/cockpit/tasks/main.yml
+++ b/roles/cockpit/tasks/main.yml
@@ -119,7 +119,7 @@
 
 ## Checks
 
-- name: "Import Checks for cockpit"
+- name: "Import check Tasks"
   ansible.builtin.import_tasks: "check.yml"
   when:
     - "cockpit_checks_enabled | bool"

--- a/roles/dnf/defaults/main.yml
+++ b/roles/dnf/defaults/main.yml
@@ -1,14 +1,12 @@
 ---
 # roles/dnf/defaults/main.yml
 
-## Package Management
+## DNF
 
 dnf_package_names:
   - "dnf"
   - "dnf-plugins-core"
 dnf_package_state: "present"
-
-## Configuration Management
 
 ### Please check 'man 5 dnf.conf' before changing the below values
 dnf_config_gpgcheck: "True"
@@ -18,6 +16,23 @@ dnf_config_best: "False"
 dnf_config_skip_if_unavailable: "True"
 dnf_config_fastestmirror: "True"
 dnf_config_max_parallel_downloads: "10"
+
+## DNF automatic
+
+dnf_automatic_enabled: false
+
+dnf_automatic_package_names:
+  - "dnf-automatic"
+dnf_automatic_package_state: "present"
+
+# The timer can be chosen as described below
+# dnf-automatic             : use the configuration in /etc/dnf/automatic.conf
+# dnf-automatic-notifyonly  : notify only about new updates
+# dnf-automaric-download    : download new updates
+# dnf-automatic-install     : download and install
+dnf_automatic_timer_name: "dnf-automatic-notifyonly"
+dnf_automatic_timer_state: "started"
+dnf_automatic_timer_enabled: true
 
 ## Checks
 

--- a/roles/dnf/tasks/dnf-automatic.yml
+++ b/roles/dnf/tasks/dnf-automatic.yml
@@ -1,0 +1,27 @@
+---
+# roles/dnf/tasks/dnf-automatic.yml
+
+## Package Management
+
+- name: "Manage dnf automatic Packages"
+  ansible.builtin.package:
+    name: "{{ dnf_automatic_package_names }}"
+    state: "{{ dnf_automatic_package_state }}"
+  become: true
+  tags:
+    - "dnf"
+    - "package"
+
+## Service Management
+
+- name: "Manage dnf automatic Timer"
+  ansible.builtin.service:
+    name: "{{ dnf_automatic_timer_name }}"
+    state: "{{ dnf_automatic_timer_state }}"
+    enabled: "{{ dnf_automatic_timer_enabled }}"
+  become: true
+  tags:
+    - "dnf"
+    - "service"
+    - "timer"
+...

--- a/roles/dnf/tasks/dnf.yml
+++ b/roles/dnf/tasks/dnf.yml
@@ -1,0 +1,28 @@
+---
+# roles/dnf/tasks/dnf.yml
+
+## Package Management
+
+- name: "Manage dnf Packages"
+  ansible.builtin.package:
+    name: "{{ dnf_package_names }}"
+    state: "{{ dnf_package_state }}"
+  become: true
+  tags:
+    - "dnf"
+    - "package"
+
+## Configuration Management
+
+- name: "Manage dnf Configuration"
+  ansible.builtin.template:
+    src: "dnf.conf.j2"
+    dest: "/etc/dnf/dnf.conf"
+    owner: "root"
+    group: "root"
+    mode: 0644
+  become: true
+  tags:
+    - "dnf"
+    - "configuration"
+...

--- a/roles/dnf/tasks/main.yml
+++ b/roles/dnf/tasks/main.yml
@@ -1,34 +1,28 @@
 ---
 # roles/dnf/tasks/main.yml
 
-## Package Management
+## DNF
 
-- name: "Manage dnf Packages"
-  ansible.builtin.package:
-    name: "{{ dnf_package_names }}"
-    state: "{{ dnf_package_state }}"
-  become: true
-  tags:
-    - "dnf"
-    - "package"
-
-## Configuration Management
-
-- name: "Manage dnf Configuration"
-  ansible.builtin.template:
-    src: "dnf.conf.j2"
-    dest: "/etc/dnf/dnf.conf"
-    owner: "root"
-    group: "root"
-    mode: 0644
-  become: true
+- name: "Import dnf Tasks"
+  ansible.builtin.import_tasks: "dnf.yml"
   tags:
     - "dnf"
     - "configuration"
 
+## DNF automatic
+
+- name: "Import dnf automatic Tasks"
+  ansible.builtin.import_tasks: "dnf-automatic.yml"
+  when:
+    - "dnf_automatic_enabled | bool"
+  tags:
+    - "dnf"
+    - "service"
+    - "timer"
+
 ## Checks
 
-- name: "Import Checks for dnf"
+- name: "Import check Tasks"
   ansible.builtin.import_tasks: "check.yml"
   when:
     - "dnf_checks_enabled | bool"

--- a/roles/firewalld/meta/argument_specs.yml
+++ b/roles/firewalld/meta/argument_specs.yml
@@ -9,6 +9,7 @@ argument_specs:
       firewalld_package_names:
         type: "list"
         elements: "str"
+        default: "firewalld"
         description: "Define the package names."
       firewalld_package_state:
         type: "str"

--- a/roles/firewalld/tasks/main.yml
+++ b/roles/firewalld/tasks/main.yml
@@ -60,7 +60,7 @@
 
 ## Checks
 
-- name: "Import Checks for firewalld"
+- name: "Import check Tasks"
   ansible.builtin.import_tasks: "check.yml"
   when:
     - "firewalld_checks_enabled | bool"

--- a/roles/sudo/defaults/main.yml
+++ b/roles/sudo/defaults/main.yml
@@ -16,7 +16,8 @@ sudo_conf_pwfeedback: false
 # lecture once|always|never
 sudo_conf_lecture: "once"
 # define another lecture message from a file
-#sudo_conf_lecture_file: "/path/to/file"
+# sudo_conf_lecture_file: "/path/to/file"
+# yamllint disable-line rule:line-length
 sudo_conf_secure_path: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 sudo_conf_root_user:

--- a/roles/update/README.md
+++ b/roles/update/README.md
@@ -3,23 +3,20 @@ reference: https://www.makeareadme.com/
 reference: https://commonmark.org/
 -->
 
-# Ansible - dnf
+# Ansible - update
 
-An Ansible Role to install and configure the
-[DNF package manager](https://DNF.readthedocs.io/en/latest/).
+An Ansible Role to update packages.
 
 ## Motivation
 
-[DNF](https://dnf.readthedocs.io/en/latest/) is the standard Package Manager for
-all RHEL'ish GNU/Linux derivates, like CentOS, Fedora or Red Hat Enterprise
-Linux. Configuring it properly is mandatory for most operators.
+Applying updates is a common task among operators and developers. Automating
+this process will help to make it easy and apply updates on schedule.
 
 ## Description
 
-The role install DNF and additional plugins to configure parallel downloads or
-chosing of the fastest mirror. It can be used to install and configure automatic
-updates via
-[dnf-automatic](https://dnf.readthedocs.io/en/latest/automatic.html), too.
+The role applies updates to RHEL family systems and reboots the machine, if
+updates where applied. You can also limit the scope to security and bugfix
+patches.
 
 ## Usage
 
@@ -68,16 +65,15 @@ Just a simple example, using the defaults from the role.
 
   tasks:
 
-    - name: "Import dnf Role"
+    - name: "Import update Role"
       ansible.builtin.import_role:
-        name: "whiletruedoio.general.dnf"
+        name: "whiletruedoio.general.update"
 ...
 ```
 
 #### Advanced Example
 
-You can also raise/lower or raise the parallel downloads and change the dnf
-configuration as demonstrated below.
+Apply security updates only and don't reboot the system.
 
 ```yaml
 ---
@@ -86,29 +82,12 @@ configuration as demonstrated below.
 
   tasks:
 
-    - name: "Import dnf Role"
+    - name: "Import update Role"
       ansible.builtin.import_role:
-        name: "whiletruedoio.general.dnf"
+        name: "whiletruedoio.general.update"
       vars:
-        dnf_config_parallel_downloads: 5
-...
-```
-
-Enable dnf-automatic and automatic install of updates.
-
-```yaml
----
-- name: "Advanced Example"
-  hosts: "all"
-
-  tasks:
-
-    - name: "Import dnf Role"
-      ansible.builtin.import_role:
-        name: "whiletruedoio.general.dnf"
-      vars:
-        dnf_automatic_enabled: true
-        dnf_automatic_timer_name: "dnf-automatic-install.timer"
+        update_package_security_only: true
+        update_reboot_enabled: false
 ...
 ```
 

--- a/roles/update/defaults/main.yml
+++ b/roles/update/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# roles/update/defaults/main.yml
+
+## Package Management
+update_package_names: "*"
+
+### Scope
+update_package_security_only: false
+update_package_bugfix_only: false
+
+## Reboot
+update_reboot_enabled: true
+update_reboot_timeout: 3600
+...

--- a/roles/update/handlers/main.yml
+++ b/roles/update/handlers/main.yml
@@ -1,0 +1,13 @@
+---
+# roles/update/handlers/main.yml
+
+- name: "Reboot system"
+  ansible.builtin.reboot:
+    reboot_timeout: "{{ update_reboot_timeout }}"
+  become: true
+  tags:
+    - "update"
+    - "package"
+    - "system"
+    - "reboot"
+...

--- a/roles/update/meta/argument_specs.yml
+++ b/roles/update/meta/argument_specs.yml
@@ -1,0 +1,15 @@
+---
+# roles/update/meta/argument_specs.yml
+
+argument_specs:
+  # roles/update/tasks/main.yml entry point
+  main:
+    short_description: "The main entrypoint for update."
+    options:
+      # Package Management
+      update_package_names:
+        description: "Define the package names."
+        type: "list"
+        elements: "str"
+        default: "*"
+...

--- a/roles/update/meta/main.yml
+++ b/roles/update/meta/main.yml
@@ -1,0 +1,5 @@
+---
+# roles/update/meta/main.yml
+
+dependencies: []
+...

--- a/roles/update/tasks/main.yml
+++ b/roles/update/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# roles/update/tasks/main.yml
+
+- name: "Update Packages"
+  ansible.builtin.dnf:
+    name: "{{ update_package_names }}"
+    state: "latest"
+    security: "{{ update_package_security_only }}"
+    bugfix: "{{ update_package_bugfix_only }}"
+  become: true
+  when:
+    - "update_reboot_enabled | bool"
+  notify:
+    - "Reboot System"
+  tags:
+    - "update"
+    - "package"
+    - "system"
+...


### PR DESCRIPTION
The update role can be used to update RHEL family systems. It
also supports some adjustments to install security or bug fixes
only.

I also added the dnf-automatic functionality to the dnf role and
fixed some minor code smells I found.